### PR TITLE
Update total segments count in gallery stats

### DIFF
--- a/src/pages/gallery/Gallery.jsx
+++ b/src/pages/gallery/Gallery.jsx
@@ -236,7 +236,7 @@ const Gallery = () => {
                   <span className={styles.heroStatLabel}>Carnival Editions</span>
                 </div>
                 <div className={styles.heroStat}>
-                  <span className={styles.heroStatNumber}>12+</span>
+                  <span className={styles.heroStatNumber}>8+</span>
                   <span className={styles.heroStatLabel}>Total segments</span>
                 </div>
                 <div className={styles.heroStat}>


### PR DESCRIPTION
Changed the displayed number of total segments from 12+ to 8+ in the gallery hero statistics section.